### PR TITLE
fix: Update link for draft Security Advisory in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Vulnerability Disclosure
 
 If you think you have found a potential security vulnerability,
-please open a [draft Security Advisory](https://github.com/atlanhq/agent-toolkit/security/advisories/new) via GitHub. We will coordinate verification and next steps through that secure medium.
+please open a [draft Security Advisory](https://github.com/atlanhq/atlan-sample-apps/security/advisories/new) via GitHub. We will coordinate verification and next steps through that secure medium.
 
 If English is not your first language, please try to describe the
 problem and its impact to the best of your ability. For greater detail,


### PR DESCRIPTION
Correct the link to the draft Security Advisory in the SECURITY.md file to point to the appropriate repository.