### PR TITLE
feat: atlan workflows observability app object storage support

### DIFF
--- a/workflows_observability/README.md
+++ b/workflows_observability/README.md
@@ -28,6 +28,28 @@ export ATLAN_BASE_URL=https://tenant.atlan.com
 export ATLAN_API_KEY="..."
 ```
 
+If you plan to export to an object storage service, make sure to update the Dapr `components/objectstore.yaml` file accordingly. For example, if you're using Amazon S3, use the following configuration:"
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: objectstore
+spec:
+  type: bindings.aws.s3
+  version: v1
+  metadata:
+    - name: bucket
+      value: "<BUCKET NAME>"
+    - name: region
+      value: "<BUCKET REGION>"
+    - name: accessKey
+      value: "<AWS ACCESS KEY>"
+    - name: secretKey
+      value: "<AWS SECRET KEY>"
+    - name: decodeBase64
+      value: "false"
+```
+
 ### Access the Application
 -   **Web Interface**: Open your browser and go to `http://localhost:8000` (or the port configured for `APP_HTTP_PORT`).
 -   **Temporal UI**: Access the Temporal Web UI at `http://localhost:8233` (or your Temporal UI address) to monitor workflow executions.

--- a/workflows_observability/frontend/templates/index.html
+++ b/workflows_observability/frontend/templates/index.html
@@ -29,9 +29,25 @@
 
           <label for="output_option">Output Option</label>
           <div id="output_option" style="text-align: left;">
-            <label>
+            <label style="display: block; margin-bottom: 5px;">
               <input type="radio" name="outputOption" value="Local" checked /> Local
             </label>
+            <label style="display: block;">
+              <input type="radio" name="outputOption" value="Object Storage" /> Object Storage
+            </label>
+          </div>
+
+          <div id="outputPrefixContainer" style="display: none; margin-top: 10px;">
+            <div style="display: flex; flex-direction: column;">
+              <label for="outputPrefix" style="margin-bottom: 4px;">Output Prefix</label>
+              <input
+                type="text"
+                id="outputPrefix"
+                name="outputPrefix"
+                placeholder="Enter output prefix for the object storage"
+                style="padding: 6px; font-size: 14px;"
+              />
+            </div>
           </div>
 
           <button id="runWorkflowButton" type="submit">Run Workflow</button>
@@ -70,6 +86,22 @@
 
         // Bind form submission
         const form = document.getElementById("nameForm");
+        const outputRadios = document.querySelectorAll('input[name="outputOption"]');
+        const outputPrefixContainer = document.getElementById("outputPrefixContainer");
+        const outputPrefixInput = document.getElementById("outputPrefix");
+
+        // Toggle Output Prefix visibility
+        outputRadios.forEach((radio) => {
+          radio.addEventListener("change", () => {
+            if (radio.value === "Object Storage" && radio.checked) {
+              outputPrefixContainer.style.display = "block";
+            } else if (radio.value === "Local" && radio.checked) {
+              outputPrefixContainer.style.display = "none";
+              outputPrefixInput.value = "";
+            }
+          });
+        });
+
         if (form) {
           form.addEventListener("submit", async function handleSubmit(event) {
             event.preventDefault();
@@ -77,6 +109,7 @@
 
             const dateInput = document.getElementById("workflow_date").value;
             const outputType = document.querySelector('input[name="outputOption"]:checked')?.value;
+            const outputPrefix = outputPrefixInput.value || "";
             const runButton = document.getElementById("runWorkflowButton");
             const resultDiv = document.getElementById("successModal");
 
@@ -94,7 +127,8 @@
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                   selectedDate: dateInput,
-                  outputType
+                  outputType,
+                  outputPrefix
                 }),
               });
 

--- a/workflows_observability/helpers.py
+++ b/workflows_observability/helpers.py
@@ -1,6 +1,7 @@
 from pyatlan.client.atlan import AtlanClient
 from pyatlan.model.enums import AtlanWorkflowPhase
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.outputs.objectstore import ObjectStoreOutput
 from temporalio import activity
 import os
 
@@ -24,7 +25,7 @@ def get_atlan_client() -> AtlanClient:
     """
     base_url = os.getenv("ATLAN_BASE_URL")
     api_key = os.getenv("ATLAN_API_KEY")
-
+    
     if not base_url or not api_key:
         raise ValueError("Missing required environment variables: ATLAN_BASE_URL and/or ATLAN_API_KEY")
 
@@ -59,4 +60,32 @@ def save_result_locally(result, local_directory: str) -> None:
 
     except Exception as e:
         logger.error(f"Error saving workflow result locally: {str(e)}", exc_info=e)
+        raise e
+    
+
+async def save_result_object_storage(output_prefix: str, local_directory: str) -> None:
+    """
+    Uploads the contents of a local directory to an object storage location under a specified prefix.
+
+    This function is typically used to persist the results of a workflow run by saving files
+    from a local path to a remote object store (e.g., S3, GCS), using the provided output prefix
+    as the destination path.
+
+    Args:
+        output_prefix (str): The prefix path under which the files will be stored in object storage.
+        local_directory (str): The local directory containing files to be uploaded.
+
+    Raises:
+        OSError: If there is an issue accessing the local directory or files.
+        Exception: For any other errors during the upload process.
+    """
+    try:
+        await ObjectStoreOutput.push_files_to_object_store(
+            output_prefix=output_prefix,
+            input_files_path=local_directory
+        )
+        logger.info("Files pushed to object storage.")
+
+    except Exception as e:
+        logger.error(f"Error saving workflow result on object storage: {str(e)}", exc_info=e)
         raise e

--- a/workflows_observability/workflow.py
+++ b/workflows_observability/workflow.py
@@ -26,6 +26,7 @@ class WorkflowsObservabilityWorkflow(WorkflowInterface):
                 used to initialize the workflow. Expected keys include:
                 - "selectedDate" (str): The reference date (in 'YYYY-MM-DD') for retrieving workflow runs.
                 - "outputType" (str): The target destination for output data (e.g., "Local").
+                - "outputPrefix" (str): The directory path or prefix under which extracted data will be stored in the object storage.
 
         Returns:
             None
@@ -40,15 +41,16 @@ class WorkflowsObservabilityWorkflow(WorkflowInterface):
 
         selected_date: str = workflow_args.get("selectedDate", "atlan-snowflake-miner-1743729606")
         output_type: str = workflow_args.get("outputType", "Local")
+        output_prefix: str = workflow_args.get("outputPrefix", "")
         workflow.logger.info("Starting workflows observability workflow")
 
         # Process workflow runs    
         await workflow.execute_activity(
             "fetch_workflows_run",
-            (selected_date, output_type),
+            (selected_date, output_type, output_prefix),
             start_to_close_timeout=timedelta(seconds=3600),
         )
-
+            
         workflow.logger.info("Workflows observability workflow completed")
 
     @staticmethod


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- Enhanced the Workflows observability sample app to support exporting workflow run status to object storage

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
N/A


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [x] All CI checks passed
- [x] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


<!-- for any questions, reachout to #pod-app-framework or connect@atlan.com -->