### PR TITLE
fix: substitute carriage return line ending for windows build

### DIFF
--- a/connectors/mysql/deploy/Dockerfile
+++ b/connectors/mysql/deploy/Dockerfile
@@ -48,10 +48,12 @@ USER appuser
 # Download DAPR components and set up entrypoint
 RUN uv run poe download-components
 
-# Copy and set executable entrypoint
+# Copy and set executable entrypoint with line ending fix
 COPY --chown=appuser:appuser ./deploy/entrypoint.sh /app/entrypoint.sh
 USER root
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && \
+    # Fix potential Windows line endings
+    sed -i 's/\r$//' /app/entrypoint.sh
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/quickstart/ai_giphy/deploy/Dockerfile
+++ b/quickstart/ai_giphy/deploy/Dockerfile
@@ -48,10 +48,12 @@ USER appuser
 # Download DAPR components and set up entrypoint
 RUN uv run poe download-components
 
-# Copy and set executable entrypoint
+# Copy and set executable entrypoint with line ending fix
 COPY --chown=appuser:appuser ./deploy/entrypoint.sh /app/entrypoint.sh
 USER root
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && \
+    # Fix potential Windows line endings
+    sed -i 's/\r$//' /app/entrypoint.sh
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/quickstart/giphy/deploy/Dockerfile
+++ b/quickstart/giphy/deploy/Dockerfile
@@ -48,10 +48,12 @@ USER appuser
 # Download DAPR components and set up entrypoint
 RUN uv run poe download-components
 
-# Copy and set executable entrypoint
+# Copy and set executable entrypoint with line ending fix
 COPY --chown=appuser:appuser ./deploy/entrypoint.sh /app/entrypoint.sh
 USER root
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && \
+    # Fix potential Windows line endings
+    sed -i 's/\r$//' /app/entrypoint.sh
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/quickstart/hello_world/deploy/Dockerfile
+++ b/quickstart/hello_world/deploy/Dockerfile
@@ -48,10 +48,12 @@ USER appuser
 # Download DAPR components and set up entrypoint
 RUN uv run poe download-components
 
-# Copy and set executable entrypoint
+# Copy and set executable entrypoint with line ending fix
 COPY --chown=appuser:appuser ./deploy/entrypoint.sh /app/entrypoint.sh
 USER root
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && \
+    # Fix potential Windows line endings
+    sed -i 's/\r$//' /app/entrypoint.sh
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/utilities/asset_descriptor_reminder/deploy/Dockerfile
+++ b/utilities/asset_descriptor_reminder/deploy/Dockerfile
@@ -48,10 +48,12 @@ USER appuser
 # Download DAPR components and set up entrypoint
 RUN uv run poe download-components
 
-# Copy and set executable entrypoint
+# Copy and set executable entrypoint with line ending fix
 COPY --chown=appuser:appuser ./deploy/entrypoint.sh /app/entrypoint.sh
 USER root
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && \
+    # Fix potential Windows line endings
+    sed -i 's/\r$//' /app/entrypoint.sh
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/utilities/freshness_monitor/deploy/Dockerfile
+++ b/utilities/freshness_monitor/deploy/Dockerfile
@@ -48,10 +48,12 @@ USER appuser
 # Download DAPR components and set up entrypoint
 RUN uv run poe download-components
 
-# Copy and set executable entrypoint
+# Copy and set executable entrypoint with line ending fix
 COPY --chown=appuser:appuser ./deploy/entrypoint.sh /app/entrypoint.sh
 USER root
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && \
+    # Fix potential Windows line endings
+    sed -i 's/\r$//' /app/entrypoint.sh
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/utilities/workflows_observability/deploy/Dockerfile
+++ b/utilities/workflows_observability/deploy/Dockerfile
@@ -48,10 +48,12 @@ USER appuser
 # Download DAPR components and set up entrypoint
 RUN uv run poe download-components
 
-# Copy and set executable entrypoint
+# Copy and set executable entrypoint with line ending fix
 COPY --chown=appuser:appuser ./deploy/entrypoint.sh /app/entrypoint.sh
 USER root
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && \
+    # Fix potential Windows line endings
+    sed -i 's/\r$//' /app/entrypoint.sh
 USER appuser
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
### Changelog
<!-- Provide a clear and concise description of the changes in this PR in bullet points -->
- fix substitute carriage return line ending for windows build

### Additional context (e.g. screenshots, logs, links)
<!-- Provide a clear additional context, dependencies & links in bullet points -->
<!-- links could be jira, slack, docs, etc. -->
- _to be added_


### Checklist
<!-- Mark [x] the appropriate option, helps the reviewer to verify the changes -->
- [ ] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


<!-- for any questions, reachout to #pod-app-framework or connect@atlan.com -->