### PR TITLE
Fix: Update deprecated Dapr flag for compatibility

### DIFF
--- a/quickstart/ai_giphy/pyproject.toml
+++ b/quickstart/ai_giphy/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 ]
 
 [tool.poe.tasks]
-start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 3000 --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-http-max-request-size 1024 --resources-path components"
+start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 3000 --dapr-http-port 3500 --dapr-grpc-port 50001 --max-body-size 1024 --resources-path components"
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 start-deps.shell = "poe start-dapr & poe start-temporal &"
 stop-deps.shell = "lsof -ti:3000,3500,7233,50001 | xargs kill -9 2>/dev/null || true"

--- a/quickstart/giphy/pyproject.toml
+++ b/quickstart/giphy/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
 ]
 
 [tool.poe.tasks]
-start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 3000 --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-http-max-request-size 1024 --resources-path components"
+start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 3000 --dapr-http-port 3500 --dapr-grpc-port 50001 --max-body-size 1024 --resources-path components"
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 start-deps.shell = "poe start-dapr & poe start-temporal &"
 stop-deps.shell = "lsof -ti:3000,3500,7233,50001 | xargs kill -9 2>/dev/null || true"

--- a/quickstart/hello_world/pyproject.toml
+++ b/quickstart/hello_world/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
 ]
 
 [tool.poe.tasks]
-start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 3000 --dapr-http-port 3500 --dapr-grpc-port 50001 --dapr-http-max-request-size 1024 --resources-path components"
+start-dapr = "dapr run --enable-api-logging --log-level debug --app-id app --app-port 3000 --dapr-http-port 3500 --dapr-grpc-port 50001 --max-body-size 1024 --resources-path components"
 start-temporal = "temporal server start-dev --db-filename ./temporal.db"
 start-deps.shell = "poe start-dapr & poe start-temporal &"
 stop-deps.shell = "lsof -ti:3000,3500,7233,50001 | xargs kill -9 2>/dev/null || true"


### PR DESCRIPTION
### Changelog
- Updated the deprecated Dapr flag `--dapr-http-max-request-size` to `--max-body-size`.
- This change makes the sample app compatible with modern versions of the Dapr CLI, resolving the unknown flag error on startup.

### Additional context (e.g. screenshots, logs, links)
- This fix was verified by running the start-deps command before and after the change. The error was present before the fix and resolved after.
- The --max-body-size flag is the current replacement as per the `dapr --help`. Documentation seems to be lagging behind.


### Checklist
- [ ] Additional tests added (N/A - This is a configuration change verified manually)
- [x] All CI checks passed
- [ ] Relevant documentation updated (N/A - This change requires no documentation update)

<!-- for any cautionary notes, use https://github.com/orgs/community/discussions/16925 -->


<!-- for any questions, reachout to #pod-app-framework or connect@atlan.com -->