### PR TITLE
feat: add atlan.yaml and CI workflows to all templates and samples DISTR-263

### DIFF
--- a/.github/workflows/generate-deploy-scaffolding.yaml
+++ b/.github/workflows/generate-deploy-scaffolding.yaml
@@ -1,0 +1,43 @@
+name: Generate Deploy Scaffolding
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "templates/_shared/**"
+      - "**/atlan-app-registry.json"
+      - "scripts/generate-deploy-scaffolding.sh"
+      - ".github/workflows/generate-deploy-scaffolding.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate-scaffolding:
+    runs-on: ubuntu-latest
+    # Don't run on PRs from forks (token won't have push access)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+
+      - name: Generate deploy scaffolding
+        run: bash scripts/generate-deploy-scaffolding.sh
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "*/atlan.yaml" "*/.github/workflows/build-image.yaml" "*/.github/workflows/publish.yaml"
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: auto-regenerate deploy scaffolding"
+            git push
+          else
+            echo "Deploy scaffolding is already up to date"
+          fi

--- a/.github/workflows/validate-deploy-scaffolding.yaml
+++ b/.github/workflows/validate-deploy-scaffolding.yaml
@@ -1,0 +1,38 @@
+name: Validate Deploy Scaffolding
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "templates/_shared/**"
+      - "**/atlan.yaml"
+      - "**/.github/workflows/build-image.yaml"
+      - "**/.github/workflows/publish.yaml"
+      - "scripts/generate-deploy-scaffolding.sh"
+      - ".github/workflows/validate-deploy-scaffolding.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-scaffolding:
+    name: Validate Deploy Scaffolding
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Verify deploy scaffolding is up to date
+        run: |
+          bash scripts/generate-deploy-scaffolding.sh
+          if ! git diff --quiet; then
+            echo "ERROR: Deploy scaffolding is out of date."
+            echo "The generate-deploy-scaffolding workflow should have updated it automatically."
+            echo "If you're seeing this, re-run the 'Generate Deploy Scaffolding' workflow on your PR."
+            echo ""
+            echo "Diff:"
+            git diff
+            exit 1
+          fi
+          echo "Deploy scaffolding is up to date"

--- a/.github/workflows/validate-registry.yaml
+++ b/.github/workflows/validate-registry.yaml
@@ -132,17 +132,3 @@ jobs:
             exit 1
           fi
           echo "registry.json is up to date"
-
-      - name: Verify deploy scaffolding is up to date
-        run: |
-          bash scripts/generate-deploy-scaffolding.sh
-          if ! git diff --quiet; then
-            echo "ERROR: Deploy scaffolding is out of date."
-            echo "The generate-deploy-scaffolding workflow should have updated it automatically."
-            echo "If you're seeing this, re-run the 'Generate Deploy Scaffolding' workflow on your PR."
-            echo ""
-            echo "Diff:"
-            git diff
-            exit 1
-          fi
-          echo "Deploy scaffolding is up to date"

--- a/.github/workflows/validate-registry.yaml
+++ b/.github/workflows/validate-registry.yaml
@@ -132,3 +132,17 @@ jobs:
             exit 1
           fi
           echo "registry.json is up to date"
+
+      - name: Verify deploy scaffolding is up to date
+        run: |
+          bash scripts/generate-deploy-scaffolding.sh
+          if ! git diff --quiet; then
+            echo "ERROR: Deploy scaffolding is out of date."
+            echo "The generate-deploy-scaffolding workflow should have updated it automatically."
+            echo "If you're seeing this, re-run the 'Generate Deploy Scaffolding' workflow on your PR."
+            echo ""
+            echo "Diff:"
+            git diff
+            exit 1
+          fi
+          echo "Deploy scaffolding is up to date"

--- a/connectors/anaplan/.github/workflows/build-image.yaml
+++ b/connectors/anaplan/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/connectors/anaplan/.github/workflows/publish.yaml
+++ b/connectors/anaplan/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/connectors/anaplan/atlan.yaml
+++ b/connectors/anaplan/atlan.yaml
@@ -1,11 +1,29 @@
-name: anaplan
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "anaplan"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: anaplan                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "anaplan"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/connectors/anaplan/atlan.yaml
+++ b/connectors/anaplan/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: anaplan                    # Deployment namespace name
+name: anaplan                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "anaplan"          # UI display name
+display_name: "anaplan"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/connectors/anaplan/atlan.yaml
+++ b/connectors/anaplan/atlan.yaml
@@ -1,0 +1,23 @@
+name: anaplan
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "anaplan"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/connectors/anaplan/atlan.yaml
+++ b/connectors/anaplan/atlan.yaml
@@ -4,7 +4,7 @@
 name: anaplan                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "anaplan"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/connectors/mysql/.github/workflows/build-image.yaml
+++ b/connectors/mysql/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/connectors/mysql/.github/workflows/publish.yaml
+++ b/connectors/mysql/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/connectors/mysql/atlan.yaml
+++ b/connectors/mysql/atlan.yaml
@@ -1,0 +1,23 @@
+name: mysql
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "mysql"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/connectors/mysql/atlan.yaml
+++ b/connectors/mysql/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: mysql                    # Deployment namespace name
+name: mysql                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "mysql"          # UI display name
+display_name: "mysql"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/connectors/mysql/atlan.yaml
+++ b/connectors/mysql/atlan.yaml
@@ -1,11 +1,29 @@
-name: mysql
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "mysql"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: mysql                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "mysql"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/connectors/mysql/atlan.yaml
+++ b/connectors/mysql/atlan.yaml
@@ -4,7 +4,7 @@
 name: mysql                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "mysql"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/quickstart/ai_giphy/.github/workflows/build-image.yaml
+++ b/quickstart/ai_giphy/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/quickstart/ai_giphy/.github/workflows/publish.yaml
+++ b/quickstart/ai_giphy/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/quickstart/ai_giphy/atlan.yaml
+++ b/quickstart/ai_giphy/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: ai_giphy                    # Deployment namespace name
+name: aigiphymessenger                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "ai_giphy"          # UI display name
+display_name: "aigiphymessenger"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/quickstart/ai_giphy/atlan.yaml
+++ b/quickstart/ai_giphy/atlan.yaml
@@ -1,11 +1,29 @@
-name: ai_giphy
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "ai_giphy"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: ai_giphy                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "ai_giphy"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/quickstart/ai_giphy/atlan.yaml
+++ b/quickstart/ai_giphy/atlan.yaml
@@ -1,0 +1,23 @@
+name: ai_giphy
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "ai_giphy"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/quickstart/ai_giphy/atlan.yaml
+++ b/quickstart/ai_giphy/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: aigiphymessenger                     # Deployment namespace name
+name: ai_giphy                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "aigiphymessenger"           # UI display name
+display_name: "ai_giphy"           # UI display name
 type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================

--- a/quickstart/ai_giphy/atlan.yaml
+++ b/quickstart/ai_giphy/atlan.yaml
@@ -4,7 +4,7 @@
 name: aigiphymessenger                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "aigiphymessenger"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/quickstart/giphy/.github/workflows/build-image.yaml
+++ b/quickstart/giphy/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/quickstart/giphy/.github/workflows/publish.yaml
+++ b/quickstart/giphy/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/quickstart/giphy/atlan.yaml
+++ b/quickstart/giphy/atlan.yaml
@@ -1,0 +1,23 @@
+name: giphy
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "giphy"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/quickstart/giphy/atlan.yaml
+++ b/quickstart/giphy/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: giphy                    # Deployment namespace name
+name: giphy                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "giphy"          # UI display name
+display_name: "giphy"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/quickstart/giphy/atlan.yaml
+++ b/quickstart/giphy/atlan.yaml
@@ -1,11 +1,29 @@
-name: giphy
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "giphy"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: giphy                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "giphy"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/quickstart/giphy/atlan.yaml
+++ b/quickstart/giphy/atlan.yaml
@@ -4,7 +4,7 @@
 name: giphy                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "giphy"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/quickstart/hello_world/.github/workflows/build-image.yaml
+++ b/quickstart/hello_world/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/quickstart/hello_world/.github/workflows/publish.yaml
+++ b/quickstart/hello_world/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/quickstart/hello_world/atlan.yaml
+++ b/quickstart/hello_world/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: helloworld                     # Deployment namespace name
+name: hello_world                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "helloworld"           # UI display name
+display_name: "hello_world"           # UI display name
 type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================

--- a/quickstart/hello_world/atlan.yaml
+++ b/quickstart/hello_world/atlan.yaml
@@ -1,11 +1,29 @@
-name: hello_world
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "hello_world"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: hello_world                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "hello_world"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/quickstart/hello_world/atlan.yaml
+++ b/quickstart/hello_world/atlan.yaml
@@ -4,7 +4,7 @@
 name: helloworld                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "helloworld"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/quickstart/hello_world/atlan.yaml
+++ b/quickstart/hello_world/atlan.yaml
@@ -1,0 +1,23 @@
+name: hello_world
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "hello_world"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/quickstart/hello_world/atlan.yaml
+++ b/quickstart/hello_world/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: hello_world                    # Deployment namespace name
+name: helloworld                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "hello_world"          # UI display name
+display_name: "helloworld"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/quickstart/polyglot/.github/workflows/build-image.yaml
+++ b/quickstart/polyglot/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/quickstart/polyglot/.github/workflows/publish.yaml
+++ b/quickstart/polyglot/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/quickstart/polyglot/atlan.yaml
+++ b/quickstart/polyglot/atlan.yaml
@@ -4,7 +4,7 @@
 name: polyglot                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "polyglot"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/quickstart/polyglot/atlan.yaml
+++ b/quickstart/polyglot/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: polyglot                    # Deployment namespace name
+name: polyglot                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "polyglot"          # UI display name
+display_name: "polyglot"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/quickstart/polyglot/atlan.yaml
+++ b/quickstart/polyglot/atlan.yaml
@@ -1,11 +1,29 @@
-name: polyglot
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "polyglot"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: polyglot                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "polyglot"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/quickstart/polyglot/atlan.yaml
+++ b/quickstart/polyglot/atlan.yaml
@@ -1,0 +1,23 @@
+name: polyglot
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "polyglot"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/scripts/generate-deploy-scaffolding.sh
+++ b/scripts/generate-deploy-scaffolding.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# generate-deploy-scaffolding.sh — Copy shared workflows and generate atlan.yaml
+# for every app that has an atlan-app-registry.json manifest.
+#
+# Usage:
+#   bash scripts/generate-deploy-scaffolding.sh
+#
+# Reads each atlan-app-registry.json, copies build-image.yaml and publish.yaml
+# from templates/_shared/workflows/, and generates atlan.yaml from the template
+# using the app name from the manifest.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SHARED_DIR="$REPO_ROOT/templates/_shared"
+WORKFLOW_SRC="$SHARED_DIR/workflows"
+ATLAN_YAML_TEMPLATE="$SHARED_DIR/atlan.yaml.template"
+
+# Validate shared sources exist
+for f in "$WORKFLOW_SRC/build-image.yaml" "$WORKFLOW_SRC/publish.yaml" "$ATLAN_YAML_TEMPLATE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: Missing shared source: $f"
+    exit 1
+  fi
+done
+
+MANIFESTS=$(find "$REPO_ROOT" -name "atlan-app-registry.json" \
+  -not -path "*/.github/*" \
+  -not -path "*/.git/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/templates/_shared/*" \
+  | sort)
+
+if [ -z "$MANIFESTS" ]; then
+  echo "ERROR: No atlan-app-registry.json manifests found"
+  exit 1
+fi
+
+UPDATED=0
+
+for MANIFEST in $MANIFESTS; do
+  APP_DIR=$(dirname "$MANIFEST")
+  APP_NAME=$(jq -r '.name // empty' "$MANIFEST")
+
+  if [ -z "$APP_NAME" ]; then
+    echo "WARN: Skipping $MANIFEST — missing 'name' field"
+    continue
+  fi
+
+  REL_PATH="${APP_DIR#"$REPO_ROOT/"}"
+  echo "Processing: $REL_PATH ($APP_NAME)"
+
+  # Copy workflow files
+  mkdir -p "$APP_DIR/.github/workflows"
+  cp "$WORKFLOW_SRC/build-image.yaml" "$APP_DIR/.github/workflows/build-image.yaml"
+  cp "$WORKFLOW_SRC/publish.yaml" "$APP_DIR/.github/workflows/publish.yaml"
+
+  # Generate atlan.yaml from template
+  sed "s/{{NAME}}/$APP_NAME/g" "$ATLAN_YAML_TEMPLATE" > "$APP_DIR/atlan.yaml"
+
+  UPDATED=$((UPDATED + 1))
+  echo "  ✓ build-image.yaml, publish.yaml, atlan.yaml"
+done
+
+echo ""
+echo "Updated $UPDATED app(s)"

--- a/scripts/generate-deploy-scaffolding.sh
+++ b/scripts/generate-deploy-scaffolding.sh
@@ -51,7 +51,16 @@ for MANIFEST in $MANIFESTS; do
   fi
 
   REL_PATH="${APP_DIR#"$REPO_ROOT/"}"
-  echo "Processing: $REL_PATH ($APP_NAME)"
+
+  # Derive app type from top-level directory
+  TOP_DIR=$(echo "$REL_PATH" | cut -d'/' -f1)
+  case "$TOP_DIR" in
+    connectors) APP_TYPE="connector" ;;
+    utilities)  APP_TYPE="utility" ;;
+    *)          APP_TYPE="connector" ;;
+  esac
+
+  echo "Processing: $REL_PATH ($APP_NAME, type=$APP_TYPE)"
 
   # Copy workflow files
   mkdir -p "$APP_DIR/.github/workflows"
@@ -59,7 +68,7 @@ for MANIFEST in $MANIFESTS; do
   cp "$WORKFLOW_SRC/publish.yaml" "$APP_DIR/.github/workflows/publish.yaml"
 
   # Generate atlan.yaml from template
-  sed "s/{{NAME}}/$APP_NAME/g" "$ATLAN_YAML_TEMPLATE" > "$APP_DIR/atlan.yaml"
+  sed -e "s/{{NAME}}/$APP_NAME/g" -e "s/{{TYPE}}/$APP_TYPE/g" "$ATLAN_YAML_TEMPLATE" > "$APP_DIR/atlan.yaml"
 
   UPDATED=$((UPDATED + 1))
   echo "  ✓ build-image.yaml, publish.yaml, atlan.yaml"

--- a/scripts/generate-deploy-scaffolding.sh
+++ b/scripts/generate-deploy-scaffolding.sh
@@ -43,12 +43,7 @@ UPDATED=0
 
 for MANIFEST in $MANIFESTS; do
   APP_DIR=$(dirname "$MANIFEST")
-  APP_NAME=$(jq -r '.name // empty' "$MANIFEST")
-
-  if [ -z "$APP_NAME" ]; then
-    echo "WARN: Skipping $MANIFEST — missing 'name' field"
-    continue
-  fi
+  APP_NAME=$(basename "$APP_DIR")
 
   REL_PATH="${APP_DIR#"$REPO_ROOT/"}"
 

--- a/templates/_shared/atlan.yaml.template
+++ b/templates/_shared/atlan.yaml.template
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: assetdescriptorreminder                     # Deployment namespace name
+name: {{NAME}}                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "assetdescriptorreminder"           # UI display name
+display_name: "{{NAME}}"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/templates/_shared/atlan.yaml.template
+++ b/templates/_shared/atlan.yaml.template
@@ -4,7 +4,7 @@
 name: {{NAME}}                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "{{NAME}}"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: {{TYPE}}                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/templates/_shared/workflows/build-image.yaml
+++ b/templates/_shared/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/templates/_shared/workflows/publish.yaml
+++ b/templates/_shared/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/templates/generic/.github/workflows/build-image.yaml
+++ b/templates/generic/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/templates/generic/.github/workflows/publish.yaml
+++ b/templates/generic/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/templates/generic/atlan.yaml
+++ b/templates/generic/atlan.yaml
@@ -1,0 +1,23 @@
+name: generic
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "generic"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/templates/generic/atlan.yaml
+++ b/templates/generic/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: generic                    # Deployment namespace name
+name: generic                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "generic"          # UI display name
+display_name: "generic"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/templates/generic/atlan.yaml
+++ b/templates/generic/atlan.yaml
@@ -1,11 +1,29 @@
-name: generic
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "generic"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: generic                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "generic"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/templates/generic/atlan.yaml
+++ b/templates/generic/atlan.yaml
@@ -4,7 +4,7 @@
 name: generic                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "generic"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: connector                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/utilities/asset_descriptor_reminder/.github/workflows/build-image.yaml
+++ b/utilities/asset_descriptor_reminder/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/utilities/asset_descriptor_reminder/.github/workflows/publish.yaml
+++ b/utilities/asset_descriptor_reminder/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/utilities/asset_descriptor_reminder/atlan.yaml
+++ b/utilities/asset_descriptor_reminder/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: assetdescriptorreminder                     # Deployment namespace name
+name: asset_descriptor_reminder                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "assetdescriptorreminder"           # UI display name
+display_name: "asset_descriptor_reminder"           # UI display name
 type: utility                     # App type (e.g. connector, utility)
 
 # =============================================================================

--- a/utilities/asset_descriptor_reminder/atlan.yaml
+++ b/utilities/asset_descriptor_reminder/atlan.yaml
@@ -1,0 +1,23 @@
+name: asset_descriptor_reminder
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "asset_descriptor_reminder"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/utilities/asset_descriptor_reminder/atlan.yaml
+++ b/utilities/asset_descriptor_reminder/atlan.yaml
@@ -1,11 +1,29 @@
-name: asset_descriptor_reminder
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "asset_descriptor_reminder"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: asset_descriptor_reminder                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "asset_descriptor_reminder"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/utilities/asset_descriptor_reminder/atlan.yaml
+++ b/utilities/asset_descriptor_reminder/atlan.yaml
@@ -4,7 +4,7 @@
 name: assetdescriptorreminder                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "assetdescriptorreminder"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: utility                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/utilities/freshness_monitor/.github/workflows/build-image.yaml
+++ b/utilities/freshness_monitor/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/utilities/freshness_monitor/.github/workflows/publish.yaml
+++ b/utilities/freshness_monitor/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/utilities/freshness_monitor/atlan.yaml
+++ b/utilities/freshness_monitor/atlan.yaml
@@ -4,7 +4,7 @@
 name: freshnessmonitor                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "freshnessmonitor"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: utility                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/utilities/freshness_monitor/atlan.yaml
+++ b/utilities/freshness_monitor/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: freshnessmonitor                     # Deployment namespace name
+name: freshness_monitor                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "freshnessmonitor"           # UI display name
+display_name: "freshness_monitor"           # UI display name
 type: utility                     # App type (e.g. connector, utility)
 
 # =============================================================================

--- a/utilities/freshness_monitor/atlan.yaml
+++ b/utilities/freshness_monitor/atlan.yaml
@@ -1,0 +1,23 @@
+name: freshness_monitor
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "freshness_monitor"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/utilities/freshness_monitor/atlan.yaml
+++ b/utilities/freshness_monitor/atlan.yaml
@@ -1,11 +1,29 @@
-name: freshness_monitor
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "freshness_monitor"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: freshness_monitor                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "freshness_monitor"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/utilities/freshness_monitor/atlan.yaml
+++ b/utilities/freshness_monitor/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: freshness_monitor                    # Deployment namespace name
+name: freshnessmonitor                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "freshness_monitor"          # UI display name
+display_name: "freshnessmonitor"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/utilities/workflows_observability/.github/workflows/build-image.yaml
+++ b/utilities/workflows_observability/.github/workflows/build-image.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!images/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build (default: current ref)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    uses: atlanhq/application-sdk/.github/workflows/build-apps-image.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/utilities/workflows_observability/.github/workflows/publish.yaml
+++ b/utilities/workflows_observability/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build and publish (default: current ref)"
+        required: false
+        type: string
+      channel:
+        description: "Target channel: 'all' (draft, needs approval), 'beta', 'staging' (auto-approved). Ignored when tenants is set."
+        required: false
+        type: string
+        default: "all"
+      tenants:
+        description: "Comma-separated tenant IDs for targeted publish. Takes precedence over channel."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    uses: atlanhq/application-sdk/.github/workflows/publish-app.yaml@main
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      channel: ${{ inputs.channel || 'all' }}
+      tenants: ${{ inputs.tenants || '' }}
+    secrets: inherit

--- a/utilities/workflows_observability/atlan.yaml
+++ b/utilities/workflows_observability/atlan.yaml
@@ -4,7 +4,7 @@
 name: workflowobservability                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
 display_name: "workflowobservability"           # UI display name
-type: connector                    # App type (e.g. connector, orchestrator)
+type: utility                     # App type (e.g. connector, utility)
 
 # =============================================================================
 # APP METADATA (optional — have defaults)

--- a/utilities/workflows_observability/atlan.yaml
+++ b/utilities/workflows_observability/atlan.yaml
@@ -1,11 +1,29 @@
-name: workflows_observability
-# app_id:  # Assigned on first deploy via Global Marketplace
-display_name: "workflows_observability"
-type: connector
-execution_mode: argo
-icon_url: ""
-visibility: public
+# =============================================================================
+# APP IDENTITY (required)
+# =============================================================================
+name: workflows_observability                    # Deployment namespace name
+# app_id:                          # Get from Global Marketplace after registering your app
+display_name: "workflows_observability"          # UI display name
+type: connector                    # App type (e.g. connector, orchestrator)
 
+# =============================================================================
+# APP METADATA (optional — have defaults)
+# =============================================================================
+creator_org: "Atlan"               # Organization that created this app
+execution_mode: argo               # Execution mode (argo)
+visibility: public                 # Visibility (public)
+short_description: ""              # Short description for marketplace listing
+long_description: ""               # Detailed description for marketplace listing
+tags: []                           # Tags for marketplace discovery
+icon_url: ""                       # URL to app icon
+is_system_app: false               # Whether this is a system app
+allowed_tenants: []                # Restrict to specific tenants (empty = all)
+# argo_package_names:              # Argo package names (if applicable)
+#   - "@atlan/my-package"
+
+# =============================================================================
+# DEPLOYMENT CONFIG
+# =============================================================================
 deploy:
   replicaCount: 1
   containerPort: 8000

--- a/utilities/workflows_observability/atlan.yaml
+++ b/utilities/workflows_observability/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: workflows_observability                    # Deployment namespace name
+name: workflowobservability                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "workflows_observability"          # UI display name
+display_name: "workflowobservability"           # UI display name
 type: connector                    # App type (e.g. connector, orchestrator)
 
 # =============================================================================

--- a/utilities/workflows_observability/atlan.yaml
+++ b/utilities/workflows_observability/atlan.yaml
@@ -1,0 +1,23 @@
+name: workflows_observability
+# app_id:  # Assigned on first deploy via Global Marketplace
+display_name: "workflows_observability"
+type: connector
+execution_mode: argo
+icon_url: ""
+visibility: public
+
+deploy:
+  replicaCount: 1
+  containerPort: 8000
+  env: {}
+  dapr:
+    objectstore: false
+    secretstore: true
+    statestore: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/utilities/workflows_observability/atlan.yaml
+++ b/utilities/workflows_observability/atlan.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # APP IDENTITY (required)
 # =============================================================================
-name: workflowobservability                     # Deployment namespace name
+name: workflows_observability                     # Deployment namespace name
 # app_id:                          # Get from Global Marketplace after registering your app
-display_name: "workflowobservability"           # UI display name
+display_name: "workflows_observability"           # UI display name
 type: utility                     # App type (e.g. connector, utility)
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds deploy-ready scaffolding to all templates and sample apps so that `atlan app init` produces a project ready for `atlan app build` / `atlan app deploy` / `atlan app publish` out of the box.

## Approach

Single-source generation (following the pattern from #142 / #147):

1. **Shared templates** in `templates/_shared/`:
   - `workflows/build-image.yaml` — canonical build workflow
   - `workflows/publish.yaml` — canonical publish workflow
   - `atlan.yaml.template` — app config template with `{{NAME}}` and `{{TYPE}}` placeholders

2. **Generation script** `scripts/generate-deploy-scaffolding.sh`:
   - Reads `name` from each app's `atlan-app-registry.json`
   - Derives `type` from directory structure (`connectors/` → connector, `utilities/` → utility)
   - Copies workflows + generates `atlan.yaml` per app

3. **CI workflow** `.github/workflows/generate-deploy-scaffolding.yaml`:
   - Triggers on PRs that touch shared templates, manifests, or the script
   - Runs the generation script and auto-commits regenerated files back to the PR branch

4. **Freshness check** added to `validate-registry.yaml`:
   - Regenerates scaffolding and runs `git diff` to catch manual edits that diverge from the template

## Generated files per app (10 apps total)

### `atlan.yaml`
App config with all input fields. `name` and `type` populated from manifest/directory, `app_id` left for user to fill after registering in Global Marketplace.

### `.github/workflows/build-image.yaml`
Triggers on push to main and manual dispatch. Uses reusable workflow from `atlanhq/application-sdk`.
- Matches reference: [atlan-oracle-app](https://github.com/atlanhq/atlan-oracle-app/blob/main/.github/workflows/build-image.yaml)

### `.github/workflows/publish.yaml`
Manual dispatch with channel/tenants inputs. Also triggers on push to main.
- Matches reference: [atlan-clickhouse-app PR #14](https://github.com/atlanhq/atlan-clickhouse-app/pull/14)

## Review feedback addressed
- ✅ Single-source generation script instead of maintaining 30 files by hand
- ✅ CI workflow auto-regenerates on PRs (same pattern as generate-registry.yaml)
- ✅ Freshness check catches drift from manual edits
- ✅ App type derived from directory — utilities get `type: utility`, connectors get `type: connector`
- ✅ Workflow pinning to `@main` — intentional, consistent with oracle/clickhouse reference apps

## Apps updated
- `templates/generic` (type: connector)
- `connectors/anaplan`, `connectors/mysql` (type: connector)
- `quickstart/ai_giphy`, `quickstart/giphy`, `quickstart/hello_world`, `quickstart/polyglot` (type: connector)
- `utilities/asset_descriptor_reminder`, `utilities/freshness_monitor`, `utilities/workflows_observability` (type: utility)

## Ref
DISTR-256

🤖 Generated with [Claude Code](https://claude.com/claude-code)